### PR TITLE
Fix: Travis CI being unable to start GUI tests (#473)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,15 @@
 language: node_js
 
+services:
+  - xvfb
+
+addons:
+  apt:
+    sources:
+      - google-chrome
+    packages:
+      - google-chrome-stable
+
 node_js:
   - 'node'
   - 10
@@ -9,9 +19,7 @@ node_js:
   - 6
 
 before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
+  - export CHROME_BIN=/usr/bin/google-chrome
 
 cache:
   yarn: true


### PR DESCRIPTION
* Fix: Update travis.yml failing to start xvfb

Travis CI updated their Xenial build environment, which introduced a new way to start up XVFB for front-end builds. This broke existing builds that used the approach based on their documentation.

* Use Chrome addon from TravisCI

* Get Google Chrome from apt-get

* Fix out-of-date chrome path in travis.yml